### PR TITLE
perf(snipe): Use `StaticQueues` with `O(1)` methods

### DIFF
--- a/benchmark/benchmark.ts
+++ b/benchmark/benchmark.ts
@@ -1,1 +1,3 @@
-import "./suites/queue";
+// Skipped for being much slower, and unused
+// import "./suites/queue";
+import "./suites/staticQueue";

--- a/benchmark/suites/staticQueue.ts
+++ b/benchmark/suites/staticQueue.ts
@@ -1,0 +1,26 @@
+import { add, suite, complete, cycle } from "benny";
+import { StaticQueue } from "../../src/classes/StaticQueue";
+
+const q1 = new StaticQueue(3);
+const q2 = new StaticQueue(3);
+q2.enQueue(3);
+
+export default suite(
+  "StaticQueue",
+
+  add("Enqueue", () => {
+    q1.enQueue(2);
+  }),
+  add("Dequeue", () => {
+    q2.deQueue();
+  }),
+  add("Peek", () => {
+    q1.peek();
+  }),
+  add("BackPeek", () => {
+    q1.backPeek();
+  }),
+
+  cycle(),
+  complete()
+);

--- a/src/classes/Snipes.ts
+++ b/src/classes/Snipes.ts
@@ -1,5 +1,5 @@
 import Collection from "@discordjs/collection";
-import { Queue } from "./Queue";
+import { StaticQueue } from "./StaticQueue";
 
 export interface SnipeObject {
   authorId: string;
@@ -8,5 +8,5 @@ export interface SnipeObject {
   timestamp: number;
 }
 
-export const snipes = new Collection<string, Queue<SnipeObject>>();
-export const editSnipes = new Collection<string, Queue<SnipeObject>>();
+export const snipes = new Collection<string, StaticQueue<SnipeObject>>();
+export const editSnipes = new Collection<string, StaticQueue<SnipeObject>>();

--- a/src/classes/StaticQueue.ts
+++ b/src/classes/StaticQueue.ts
@@ -1,0 +1,68 @@
+/** Same as `Queue`, but has a Static Size */
+export class StaticQueue<T> {
+  private _maxSize: number;
+  private _storage: { [index: number]: T } = {};
+  private _frontIndex = 0;
+  private _backIndex = -1;
+
+  /**
+   * A `Queue` with a static size. Performs better than a dynamic Queue
+   * @param maxSize Maximum Size of Queue
+   */
+  constructor(maxSize: number) {
+    this._maxSize = maxSize;
+  }
+
+  /**
+   * Enqueues an item to the front of the Queue
+   * @param item
+   */
+  public enQueue(item: T) {
+    if (this.storageLength < this._maxSize) {
+      this._storage[++this._backIndex] = item;
+    }
+  }
+
+  /**
+   * Dequeues last item of the Queue
+   */
+  public deQueue() {
+    if (this.storageLength !== 0) {
+      delete this._storage[this._frontIndex++];
+    }
+  }
+
+  /**
+   * Get value of specified index, starting at the front
+   * @param index Index to return. Defaults to 0
+   * @returns Value at stored index
+   */
+  public peek(index = 0) {
+    return this._storage[this._frontIndex + index];
+  }
+
+  /**
+   * Get value of specified index, starting from the back
+   * @param index Index to return. Defaults to 0
+   * @returns Value at stored index
+   */
+  public backPeek(index = 0) {
+    return this._storage[this._backIndex - index];
+  }
+
+  public get isEmpty() {
+    return !this.storageLength;
+  }
+
+  public get isFull() {
+    return this.storageLength === this.maxSize ? true : false;
+  }
+
+  public get storageLength() {
+    return this._backIndex - this._frontIndex + 1;
+  }
+
+  public get maxSize() {
+    return this._maxSize;
+  }
+}

--- a/src/commands/helpers/snipe.ts
+++ b/src/commands/helpers/snipe.ts
@@ -13,7 +13,7 @@ export function main(
   index = index ? index : 0;
 
   const queue = collection.get(channelId);
-  const snipedObject = queue?.peek(index);
+  const snipedObject = queue?.backPeek(index);
   const author = client.users.cache.get(snipedObject?.authorId ?? "");
   const channel = client.channels.cache.get(channelId);
 

--- a/src/events/onMessageDelete.ts
+++ b/src/events/onMessageDelete.ts
@@ -1,6 +1,6 @@
 import { SnipeObject, snipes } from "../classes/Snipes";
 import { EventHandler, MyMessage } from "../../typings";
-import { Queue } from "../classes/Queue";
+import { StaticQueue } from "../classes/StaticQueue";
 
 export default <EventHandler>{
   name: "messageDelete",
@@ -14,18 +14,20 @@ export default <EventHandler>{
       let snipeQueue = snipes.get(message.channelId);
 
       if (!snipeQueue) {
-        snipes.set(message.channelId, new Queue<SnipeObject>());
-        snipeQueue = snipes.get(message.channelId);
+        snipeQueue = new StaticQueue<SnipeObject>(
+          parseInt(process.env.MAX_SNIPES ?? "10")
+        );
+        snipes.set(message.channelId, snipeQueue);
       }
 
-      snipeQueue?.enqueue({
+      snipeQueue.enQueue({
         content: message.content,
         authorId: message.author.id,
         timestamp: Date.now(),
       });
 
-      if (snipeQueue?.length === parseInt(process.env.MAX_SNIPES ?? "10")) {
-        snipeQueue.dequeue();
+      if (snipeQueue.isFull) {
+        snipeQueue.deQueue();
       }
     } catch (error) {
       message.client.log.error(error);

--- a/src/events/onMessageUpdate.ts
+++ b/src/events/onMessageUpdate.ts
@@ -1,6 +1,6 @@
 import { editSnipes, SnipeObject } from "../classes/Snipes";
 import { EventHandler, MyMessage } from "../../typings";
-import { Queue } from "../classes/Queue";
+import { StaticQueue } from "../classes/StaticQueue";
 
 export default <EventHandler>{
   name: "messageUpdate",
@@ -12,18 +12,20 @@ export default <EventHandler>{
       let snipeQueue = editSnipes.get(message.channelId);
 
       if (!snipeQueue) {
-        editSnipes.set(message.channelId, new Queue<SnipeObject>());
-        snipeQueue = editSnipes.get(message.channelId);
+        snipeQueue = new StaticQueue<SnipeObject>(
+          parseInt(process.env.MAX_SNIPES ?? "10")
+        );
+        editSnipes.set(message.channelId, snipeQueue);
       }
 
-      snipeQueue?.enqueue({
+      snipeQueue.enQueue({
         content: message.content,
         authorId: message.author.id,
         timestamp: Date.now(),
       });
 
-      if (snipeQueue?.length === parseInt(process.env.MAX_SNIPES ?? "10")) {
-        snipeQueue.dequeue();
+      if (snipeQueue.isFull) {
+        snipeQueue.deQueue();
       }
     } catch (error) {
       message.client.log.error(error);


### PR DESCRIPTION
This replaces `Queue` with `StaticQueue`, which has better performance and both `enQueue` and `deQueue` have `O(1)` time complexity

Closes #1 